### PR TITLE
Fix debian watch file matching syntax

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -10,6 +10,5 @@ version=4
 #opts="pgpsigurlmangle=s%$%.sig%"
 
 # GitHub hosted projects
-opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%diff-so-fancy_$1.orig.tar.gz%" \
-   https://github.com/so-fancy/diff-so-fancy/releases/latest \
-   (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate
+opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/diff-so-fancy-$1\.tar\.gz/ \
+  https://github.com/so-fancy/diff-so-fancy/tags .*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
uscan fails to find a match as the matching needs updated in the watch file to account for [changes in Github](https://wiki.debian.org/debian/watch#GitHub). This updates the syntax so it can find releases again using the tags page.

Before:
```
$ uscan --destdir tarballs
uscan warn: In debian/watch no matching files for watch line
  https://github.com/so-fancy/diff-so-fancy/releases/latest (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate
```

After:
```
$ uscan --destdir tarballs
uscan: Newest version of diff-so-fancy on remote site is 1.4.3, local version is 1.4.2
uscan:  => Newer package available from:
        => https://github.com/so-fancy/diff-so-fancy/archive/refs/tags/v1.4.3.tar.gz
Successfully symlinked tarballs/diff-so-fancy-1.4.3.tar.gz to tarballs/diff-so-fancy_1.4.3.orig.tar.gz.
```

Closes #3 